### PR TITLE
Replace frameworks/libs with actual app servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,15 +89,15 @@ Here are the benchmarks results ordered by increasing throughput.
 
 | App Server                             | Throughput (req/s) | Latency in ms (avg/stdev/max) |
 | :------------------------------------- | -----------------: | ----------------------------: |
-| [Rack](#rack)                          |          29208.81  |              3.13/0.34/13.28  |
-| [Plug](#plug)                          |          34053.95  |             3.11/6.95/140.31  |
+| [Puma (Rack)](#puma)                   |          29208.81  |              3.13/0.34/13.28  |
+| [Cowboy (Plug)](#cowboy)               |          34053.95  |             3.11/6.95/140.31  |
 | [Node Cluster](#node-cluster)          |          47576.68  |             2.51/3.40/120.02  |
 | [asynchttpserver](#asynchttpserver)    |          49049.54  |              2.04/0.46/46.25  |
 | [Jetty](#jetty)                        |          52398.88  |              1.90/0.43/22.45  |
 | [ServeMux](#servemux)                  |          58359.97  |              1.70/0.31/18.63  |
 | [Crystal HTTP](#crystal-http)          |          75821.32  |               1.32/0.32/7.38  |
 
-### Rack
+### Puma
 I tested ruby by using a plain [Rack](http://rack.github.io/) application with the [Puma](#http://puma.io/) application server.  
 
 ##### Bootstrap
@@ -109,7 +109,7 @@ bundle exec puma -w 8 --preload -t 16:32 app.ru
 Rack proves to be a pretty fast HTTP server: it's modular, easy to extend and almost every Ruby Web framework is Rack-compliant.
 The ability to add middlewares easily make Rack so flexible i suggest picking it in place of heavyweight frameworks (that can be added in a second time).  
 
-### Plug
+### Cowboy
 I tested Elixir by using [Plug](https://github.com/elixir-lang/plug) library that provides a [Cowboy](https://github.com/ninenines/cowboy) adapter.
 
 ##### Bootstrap


### PR DESCRIPTION
Hey everyone,

nice project!
I found a slight confusion in the results around the app servers and web frameworks listed.
Rack and Plug are not app servers, comparing them to app servers (like Jetty) is comparing apples and oranges. Reading through the description, your intentions become clear but I think we should clear this up also in the titles.

What do you think?