### PR TITLE
added fasthttp golang

### DIFF
--- a/servers/go_fasthttp_server.go
+++ b/servers/go_fasthttp_server.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/valyala/fasthttp"
+)
+
+func main() {
+	fasthttp.ListenAndServe(":9292", func(ctx *fasthttp.RequestCtx) {
+		fmt.Fprintf(ctx, "Hello World")
+	})
+}
+


### PR DESCRIPTION
Added golang fasthttp, it's +/- 30% faster than net/http on my machine.

net/http
```
➜  ~ wrk -c 100 -d 20s http://localhost:9292/
Running 20s test @ http://localhost:9292/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   773.67us    1.00ms  23.39ms   90.62%
    Req/Sec    75.70k    10.52k   89.73k    69.75%
  3013917 requests in 20.02s, 367.91MB read
Requests/sec: 150532.95
Transfer/sec:     18.38MB
```

fasthttp
```
➜  ~ wrk -c 100 -d 20s http://localhost:9292/
Running 20s test @ http://localhost:9292/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   333.74us  407.45us  14.61ms   96.78%
    Req/Sec    98.50k     4.30k  110.54k    67.00%
  3921177 requests in 20.02s, 545.97MB read
Requests/sec: 195862.13
Transfer/sec:     27.27MB
```

Crystal is single threaded? It only used 1 core on my machine and this was the result:
```
➜  ~ wrk -c 100 -d 20s http://localhost:9292/
Running 20s test @ http://localhost:9292/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.51ms  501.30us  19.89ms   95.12%
    Req/Sec    33.52k     1.77k   37.74k    91.25%
  1333977 requests in 20.02s, 128.49MB read
Requests/sec:  66632.85
Transfer/sec:      6.42MB
```

Then i run the fasthttp with only 1 core too and got this result:
```
➜  ~ wrk -c 100 -d 20s http://localhost:9292/
Running 20s test @ http://localhost:9292/
  2 threads and 100 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.15ms  645.62us   7.00ms   59.30%
    Req/Sec    43.75k     1.37k   45.56k    82.00%
  1741205 requests in 20.03s, 242.44MB read
Requests/sec:  86942.53
Transfer/sec:     12.11MB
```

