### PR TITLE
io.WriteString performs better than fmt.Fprint

### DIFF
--- a/servers/go_server.go
+++ b/servers/go_server.go
@@ -1,14 +1,14 @@
 package main
 
 import (
-	"fmt"
+	"io"
 	"log"
 	"net/http"
 )
 
 func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "Hello World")
+		io.WriteString(w, "Hello World")
 	})
 	log.Fatal(http.ListenAndServe("0.0.0.0:9292", nil))
 }


### PR DESCRIPTION
Enjoyed seeing your benchmark. Go will perform better if you use io.WriteString instead of fmt.Fprint.

See also: http://stackoverflow.com/a/37872799